### PR TITLE
Use absolute path for error messages

### DIFF
--- a/src/vscode-extras.ts
+++ b/src/vscode-extras.ts
@@ -8,7 +8,7 @@ function getOpenUrl(textDocumentUri: URL): URL {
     const basePath: unknown = sourcegraph.configuration.get().value['vscode.open.basePath']
     if (typeof basePath !== 'string') {
         throw new Error(
-            `Setting \`vscode.open.basePath\` must be set in your [user settings](${sourcegraph.internal.sourcegraphURL.href}user/settings) to open files in VS Code.`
+            `Setting \`vscode.open.basePath\` must be set in your [user settings](${new URL('/user/settings', sourcegraph.internal.sourcegraphURL.href).href}) to open files in VS Code.`
         )
     }
     if (!path.isAbsolute(basePath)) {

--- a/src/vscode-extras.ts
+++ b/src/vscode-extras.ts
@@ -8,12 +8,12 @@ function getOpenUrl(textDocumentUri: URL): URL {
     const basePath: unknown = sourcegraph.configuration.get().value['vscode.open.basePath']
     if (typeof basePath !== 'string') {
         throw new Error(
-            'Setting `vscode.open.basePath` must be set in your [user settings](/user/settings) to open files in VS Code.'
+            `Setting \`vscode.open.basePath\` must be set in your [user settings](${sourcegraph.internal.sourcegraphURL.href}user/settings) to open files in VS Code.`
         )
     }
     if (!path.isAbsolute(basePath)) {
         throw new Error(
-            `\`vscode.open.basePath\` value \`${basePath}\` is not an absolute path. Please correct the error in your [user settings](/user/settings).`
+            `\`vscode.open.basePath\` value \`${basePath}\` is not an absolute path. Please correct the error in your [user settings](${sourcegraph.internal.sourcegraphURL.href}user/settings).`
         )
     }
     const relativePath = decodeURIComponent(textDocumentUri.hash.slice('#'.length))

--- a/src/vscode-extras.ts
+++ b/src/vscode-extras.ts
@@ -13,7 +13,7 @@ function getOpenUrl(textDocumentUri: URL): URL {
     }
     if (!path.isAbsolute(basePath)) {
         throw new Error(
-            `\`vscode.open.basePath\` value \`${basePath}\` is not an absolute path. Please correct the error in your [user settings](${sourcegraph.internal.sourcegraphURL.href}user/settings).`
+            `\`vscode.open.basePath\` value \`${basePath}\` is not an absolute path. Please correct the error in your [user settings](${new URL('/user/settings', sourcegraph.internal.sourcegraphURL.href).href}).`
         )
     }
     const relativePath = decodeURIComponent(textDocumentUri.hash.slice('#'.length))


### PR DESCRIPTION
Using relative path may confuse users on code hosts when they are linked to URLs like "https://github.com/user/settings"